### PR TITLE
Do not delete all entities on restart

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
   liquibase:
     change-log: classpath:db/changelog.xml
     database-change-log-table: BR_CHANGELOG


### PR DESCRIPTION
As per https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#configurations-hbmddl

hibernate.hbm2ddl.auto (e.g. none (default value), create-only, drop, create, create-drop, validate, and update)
Setting to perform SchemaManagementTool actions automatically as part of the SessionFactory lifecycle. Valid options are defined by the externalHbm2ddlName value of the Action enum:

none
No action will be performed.

create-only
Database creation will be generated.

drop
Database dropping will be generated.

create
Database dropping will be generated followed by database creation.

create-drop
Drop the schema and recreate it on SessionFactory startup. Additionally, drop the schema on SessionFactory shutdown.

validate
Validate the database schema

update
Update the database schema